### PR TITLE
Add dynamic model discovery with file-based caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Please note that this plugin is for Vertex AI specifically, not Google AI Studio
 
 For Gemini support using AI Studio, please see [llm-gemini](https://github.com/simonw/llm-gemini) instead.
 
-Supported models:
+## Models
 
-- gemini-2.5-flash
-- gemini-2.5-pro
-- gemini-2.0-flash-lite
-- gemini-2.0-flash
-- gemini-1.5-pro
-- gemini-1.5-flash
+This plugin dynamically discovers available Gemini models from Vertex AI's Model Garden API. Models are cached in `~/.cache/llm-vertex/models.json` for 24 hours to minimize API calls. If the API is unavailable or credentials aren't configured, it falls back to: gemini-2.5-flash, gemini-2.5-pro, gemini-2.0-flash-lite, gemini-2.0-flash, gemini-1.5-pro, gemini-1.5-flash.
+
+**Environment variables:**
+
+``` shell
+export VERTEX_DISABLE_DYNAMIC_MODELS=true  # Disable dynamic fetching
+export VERTEX_CACHE_TTL=3600                # Cache TTL in seconds (default: 86400)
+```
 
 ## Installation
 

--- a/llm_vertex.py
+++ b/llm_vertex.py
@@ -1,23 +1,167 @@
 import llm
 import vertexai
 import os
-from typing import Optional
+import json
+import time
+from pathlib import Path
+from typing import Optional, List
 # from google.cloud.aiplatform_v1beta1.types import Content, Part
 from vertexai.generative_models import GenerativeModel, Part, ChatSession, Content, GenerationConfig
+
+# Cache for available models to avoid repeated API calls
+_cached_models: Optional[List[str]] = None
+
+# Fallback list of known Gemini models
+# Source: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
+FALLBACK_MODELS = [
+    'gemini-2.5-flash',
+    'gemini-2.5-pro',
+    'gemini-2.0-flash-lite',
+    'gemini-2.0-flash',
+    'gemini-1.5-pro',
+    'gemini-1.5-flash',
+]
+
+
+def get_cache_file_path() -> Path:
+    """
+    Get the path to the cache file for storing model lists.
+    Uses ~/.cache/llm-vertex/models.json on Unix-like systems.
+    """
+    cache_dir = Path.home() / '.cache' / 'llm-vertex'
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / 'models.json'
+
+
+def load_models_from_cache() -> Optional[List[str]]:
+    """
+    Load models from the cache file if it exists and is not expired.
+    Returns None if cache doesn't exist, is expired, or cannot be read.
+    Cache TTL defaults to 24 hours, configurable via VERTEX_CACHE_TTL environment variable.
+    """
+    try:
+        cache_file = get_cache_file_path()
+        if not cache_file.exists():
+            return None
+
+        with open(cache_file, 'r') as f:
+            cache_data = json.load(f)
+
+        # Check if cache is expired (default 24 hours)
+        cached_time = cache_data.get('timestamp', 0)
+        try:
+            cache_ttl = int(os.getenv('VERTEX_CACHE_TTL', '86400'))
+        except ValueError:
+            cache_ttl = 86400
+
+        if time.time() - cached_time > cache_ttl:
+            return None
+
+        return cache_data.get('models') or None
+
+    except Exception as e:
+        # If any error occurs reading cache, just return None
+        print(f"Warning: Could not read cache file: {e}")
+        return None
+
+
+def save_models_to_cache(models: List[str]) -> None:
+    """
+    Save models to the cache file with current timestamp.
+    """
+    try:
+        cache_file = get_cache_file_path()
+        cache_data = {
+            'timestamp': time.time(),
+            'models': models
+        }
+
+        with open(cache_file, 'w') as f:
+            json.dump(cache_data, f, indent=2)
+
+    except Exception as e:
+        # If we can't write cache, just log and continue
+        print(f"Warning: Could not write cache file: {e}")
+
+
+def _cache_and_return(models: List[str]) -> List[str]:
+    """
+    Helper function to cache models (both in-memory and file) and return them.
+    """
+    global _cached_models
+    _cached_models = models
+    save_models_to_cache(models)
+    return models
+
+
+def get_available_models() -> List[str]:
+    """
+    Fetch available Gemini models from Vertex AI.
+    Falls back to a hardcoded list if the API call fails.
+    Results are cached in memory and on disk to avoid repeated API calls.
+    """
+    global _cached_models
+
+    # Return in-memory cached models if available
+    if _cached_models is not None:
+        return _cached_models
+
+    # Try to load from file cache
+    cached_from_file = load_models_from_cache()
+    if cached_from_file:
+        _cached_models = cached_from_file
+        return cached_from_file
+
+    # Check if dynamic model fetching is disabled
+    if os.getenv('VERTEX_DISABLE_DYNAMIC_MODELS', '').lower() in ('true', '1', 'yes'):
+        return _cache_and_return(FALLBACK_MODELS)
+
+    try:
+        # Try to get models dynamically from Vertex AI
+        from google.cloud import aiplatform
+
+        project_id = os.getenv('VERTEX_PROJECT_ID')
+        location = os.getenv('VERTEX_LOCATION', 'us-central1')
+
+        if not project_id:
+            return _cache_and_return(FALLBACK_MODELS)
+
+        # Initialize aiplatform and get publisher models
+        aiplatform.init(project=project_id, location=location)
+        from google.cloud.aiplatform_v1beta1 import ModelGardenServiceClient
+
+        client = ModelGardenServiceClient()
+
+        # List models from Model Garden
+        models = []
+        try:
+            page_result = client.list_publisher_models(parent="publishers/google")
+
+            for model in page_result:
+                # Filter for Gemini models only
+                if model.name and 'gemini' in model.name.lower():
+                    # Extract model name from the full path (publishers/google/models/gemini-xxx)
+                    models.append(model.name.split('/')[-1])
+        except Exception as e:
+            print(f"Warning: Could not fetch models from Vertex AI: {e}")
+            return _cache_and_return(FALLBACK_MODELS)
+
+        # Return fetched models or fallback
+        return _cache_and_return(models if models else FALLBACK_MODELS)
+
+    except Exception as e:
+        print(f"Warning: Could not fetch models dynamically: {e}")
+        return _cache_and_return(FALLBACK_MODELS)
 
 
 @llm.hookimpl
 def register_models(register):
-    # Source: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
-    models = [
-        'gemini-2.5-flash',
-        'gemini-2.5-pro',
-        'gemini-2.0-flash-lite',
-        'gemini-2.0-flash',
-        'gemini-1.5-pro',
-        'gemini-1.5-flash',
-    ]
-    
+    """
+    Register available Vertex AI models with LLM.
+    Attempts to fetch models dynamically from the API, falls back to hardcoded list.
+    """
+    models = get_available_models()
+
     for model in models:
         register(Vertex(f'vertex-{model}'))
 

--- a/tests/test_llm_vertex.py
+++ b/tests/test_llm_vertex.py
@@ -6,6 +6,9 @@ import os
 sys.modules['vertexai'] = MagicMock()
 sys.modules['vertexai.generative_models'] = MagicMock()
 sys.modules['google.cloud.aiplatform_v1beta1.types'] = MagicMock()
+sys.modules['google.cloud'] = MagicMock()
+sys.modules['google.cloud.aiplatform'] = MagicMock()
+sys.modules['google.cloud.aiplatform_v1beta1'] = MagicMock()
 
 @patch.dict(os.environ, {'VERTEX_PROJECT_ID': 'test-project', 'VERTEX_LOCATION': 'us-east1'})
 def test_plugin_is_installed():
@@ -93,3 +96,122 @@ def test_model_name_extraction():
         with patch.dict(os.environ, {'VERTEX_PROJECT_ID': 'test-project', 'VERTEX_LOCATION': 'us-east1'}):
             model = llm_vertex.Vertex(model_id)
             assert model.model_name == expected_name, f"Expected {expected_name}, got {model.model_name}"
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_get_available_models_without_project_id():
+    """Test that get_available_models returns fallback models when no project ID is set."""
+    import llm_vertex
+
+    # Reset the cache
+    llm_vertex._cached_models = None
+
+    models = llm_vertex.get_available_models()
+
+    # Should return fallback models
+    assert models == llm_vertex.FALLBACK_MODELS
+
+
+@patch.dict(os.environ, {'VERTEX_DISABLE_DYNAMIC_MODELS': 'true', 'VERTEX_PROJECT_ID': 'test-project'})
+def test_get_available_models_with_dynamic_disabled():
+    """Test that get_available_models respects the disable flag."""
+    import llm_vertex
+
+    # Reset the cache
+    llm_vertex._cached_models = None
+
+    models = llm_vertex.get_available_models()
+
+    # Should return fallback models even with project ID set
+    assert models == llm_vertex.FALLBACK_MODELS
+
+
+def test_get_available_models_caching():
+    """Test that get_available_models caches results."""
+    import llm_vertex
+    from unittest.mock import patch as mock_patch
+    import tempfile
+
+    # Reset the cache
+    llm_vertex._cached_models = None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Override cache file path to use temp directory
+        temp_cache_file = os.path.join(tmpdir, 'test_models.json')
+
+        with mock_patch('llm_vertex.get_cache_file_path', return_value=temp_cache_file):
+            with patch.dict(os.environ, {}, clear=True):
+                models1 = llm_vertex.get_available_models()
+                models2 = llm_vertex.get_available_models()
+
+                # Should return the same cached list
+                assert models1 is models2
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_file_cache_persistence():
+    """Test that models are saved to and loaded from file cache."""
+    import llm_vertex
+    from unittest.mock import patch as mock_patch
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Override cache file path to use temp directory
+        from pathlib import Path
+        temp_cache_file = Path(tmpdir) / 'test_models.json'
+
+        with mock_patch('llm_vertex.get_cache_file_path', return_value=temp_cache_file):
+            # Reset the in-memory cache
+            llm_vertex._cached_models = None
+
+            # First call should create cache file
+            models1 = llm_vertex.get_available_models()
+            assert temp_cache_file.exists()
+
+            # Reset in-memory cache
+            llm_vertex._cached_models = None
+
+            # Second call should load from file
+            models2 = llm_vertex.get_available_models()
+            assert models1 == models2
+
+
+@patch.dict(os.environ, {'VERTEX_CACHE_TTL': '1'}, clear=False)
+def test_cache_expiry():
+    """Test that cache expires after TTL."""
+    import llm_vertex
+    from unittest.mock import patch as mock_patch
+    import tempfile
+    import time
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from pathlib import Path
+        temp_cache_file = Path(tmpdir) / 'test_models.json'
+
+        with mock_patch('llm_vertex.get_cache_file_path', return_value=temp_cache_file):
+            # Reset the in-memory cache
+            llm_vertex._cached_models = None
+
+            # First call creates cache
+            models1 = llm_vertex.get_available_models()
+
+            # Wait for cache to expire (TTL is 1 second)
+            time.sleep(2)
+
+            # Reset in-memory cache
+            llm_vertex._cached_models = None
+
+            # Load from file should return None due to expiry
+            cached_models = llm_vertex.load_models_from_cache()
+            assert cached_models is None
+
+
+def test_cache_file_path():
+    """Test that cache file path is correctly constructed."""
+    import llm_vertex
+    from pathlib import Path
+
+    cache_path = llm_vertex.get_cache_file_path()
+    assert cache_path.name == 'models.json'
+    assert 'llm-vertex' in str(cache_path)
+    assert cache_path.parent.exists()  # Directory should be created


### PR DESCRIPTION
_Testing out claude code's github app for this_

---

Implement dynamic model fetching from Vertex AI's Model Garden API with multi-layer caching to minimize API calls and improve performance.

## Features

- **Dynamic Model Discovery**: Automatically fetch available Gemini models from Vertex AI Model Garden API
- **Multi-Layer Caching**:
  - In-memory cache for the duration of the process
  - File-based cache (~/.cache/llm-vertex/models.json) with configurable TTL (default 24 hours)
- **Smart Fallback**: Falls back to hardcoded model list if API unavailable or credentials not configured
- **Configuration Options**:
  - VERTEX_DISABLE_DYNAMIC_MODELS: Disable dynamic fetching
  - VERTEX_CACHE_TTL: Configure cache expiry time in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)