### PR TITLE
Add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Added Python 3.14 to the GitHub Actions test workflow to ensure compatibility with the latest Python version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)